### PR TITLE
a bit more safeguarding in render_hierarchy

### DIFF
--- a/app/helpers/blacklight/hierarchy_helper.rb
+++ b/app/helpers/blacklight/hierarchy_helper.rb
@@ -35,7 +35,7 @@ module Blacklight::HierarchyHelper
   def render_hierarchy(bl_facet_field, delim='_')
     field_name = bl_facet_field.field
     prefix = field_name.gsub("#{delim}#{field_name.split(/#{delim}/).last}", '')
-    tree = facet_tree(prefix)[field_name]
+    tree = facet_tree(prefix) ? facet_tree(prefix)[field_name] : nil
     return '' unless tree
     tree.keys.sort.collect do |key|
       render_facet_hierarchy_item(field_name, tree[key], key)

--- a/app/helpers/blacklight/hierarchy_helper.rb
+++ b/app/helpers/blacklight/hierarchy_helper.rb
@@ -35,7 +35,8 @@ module Blacklight::HierarchyHelper
   def render_hierarchy(bl_facet_field, delim='_')
     field_name = bl_facet_field.field
     prefix = field_name.gsub("#{delim}#{field_name.split(/#{delim}/).last}", '')
-    tree = facet_tree(prefix) ? facet_tree(prefix)[field_name] : nil
+    facet_tree_for_prefix = facet_tree(prefix)
+    tree = facet_tree_for_prefix ? facet_tree_for_prefix[field_name] : nil
     return '' unless tree
     tree.keys.sort.collect do |key|
       render_facet_hierarchy_item(field_name, tree[key], key)


### PR DESCRIPTION
prevent render_hierarchy from erroring out when there's no facet_tree for the field