### PR TITLE
update README and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add the hierarchy-specific options to the controller configuration
       }
     }
 
-In the above configuration, 'queue_status_facet' is the full Solr field name, and ':' is the delimiter within the field.  Note that suffixes (like 'facet' in the above example) should *not* contain underscores, since the methods that deal with the Solr fields and match them to the config assume the "prefix" ('queue_status' in the above example) will be everything up to the last underscore in the field name.  See the facet_tree method for further explanation and some relevant code, as well as the render_hierarchy method for relevant code.
+In the above configuration, 'queue_status_facet' is the full Solr field name, and ':' is the delimiter within the field.  Note that suffixes ('facet' in the above example) should not contain underscores, since the methods that deal with the Solr fields and match them to the config assume the "prefix" ('queue_status' in the above example) will be everything up to the last underscore in the field name.  See the facet_tree method for further explanation and some relevant code, as well as the render_hierarchy method for relevant code.
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In your Blacklight controller configuration (usually `CatalogController`), tell 
         :partial => 'blacklight/hierarchy/facet_hierarchy'
 
 
-Add the hierarchy-specific options to the controller configuration (see the facet_tree method for further explanation and some relevant code, as well as the render_hierarchy method for relevant code)
+Add the hierarchy-specific options to the controller configuration
 
     config.facet_display = {
       :hierarchy => {
@@ -55,6 +55,7 @@ Add the hierarchy-specific options to the controller configuration (see the face
       }
     }
 
+In the above configuration, 'queue_status_facet' is the full Solr field name, and ':' is the delimiter within the field.  Note that suffixes (like 'facet' in the above example) should *not* contain underscores, since the methods that deal with the Solr fields and match them to the config assume the "prefix" ('queue_status' in the above example) will be everything up to the last underscore in the field name.  See the facet_tree method for further explanation and some relevant code, as well as the render_hierarchy method for relevant code.
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ In your Blacklight controller configuration (usually `CatalogController`), tell 
 
     config.add_facet_field 'queue_status_facet', :label => 'Queue Status', 
         :partial => 'blacklight/hierarchy/facet_hierarchy'
-    
-Add the hierarchy-specific options to the controller configuration 
+
+
+Add the hierarchy-specific options to the controller configuration (see the facet_tree method for further explanation and some relevant code, as well as the render_hierarchy method for relevant code)
 
     config.facet_display = {
       :hierarchy => {
-        'tag' => [nil]
+        'queue_status' => [['facet'], ':']
       }
     }
 
-(The `[nil]` value is present in support of rotatable facet hierarchies, which I don't have time to document right now.)
 
 ## Caveats
 

--- a/app/helpers/blacklight/hierarchy_helper.rb
+++ b/app/helpers/blacklight/hierarchy_helper.rb
@@ -64,7 +64,7 @@ module Blacklight::HierarchyHelper
   #       'exploded_tag' => [['ssim'], ':']
   #    }
   #  }
-  # then possible hkey values would be 'wf' and 'callnum'.
+  # then possible hkey values would be 'wf', 'callnum_top', and 'exploded_tag'.
   #
   # the key in the :hierarchy hash is the "prefix" for the solr field with the hierarchy info.  the value
   #  in the hash is a list, where the first element is a list of suffixes, and the second element is the delimiter

--- a/app/helpers/blacklight/hierarchy_helper.rb
+++ b/app/helpers/blacklight/hierarchy_helper.rb
@@ -74,6 +74,7 @@ module Blacklight::HierarchyHelper
   #  hash above.  ':' would be the delimiter used in all of those fields except for 'callnum_top_facet', which would 
   #  use '/'.  exploded_tag_ssim might contain values like ['Book', 'Book : Multi-Volume Work'], and callnum_top_facet 
   #  might contain values like ['LB', 'LB/2395', 'LB/2395/.C65', 'LB/2395/.C65/1991'].
+  # note: the suffixes (e.g. 'ssim' for 'exploded_tag' in the above example) can't have underscores, otherwise things break.
   def facet_tree(hkey)
     @facet_tree ||= {}
     return @facet_tree[hkey] unless @facet_tree[hkey].nil?


### PR DESCRIPTION
@ndushay @atz 

augment README and method comments so that facet_field configuration is more comprehensible for users of this gem.  this was a first pass at this fix, totally happy to take another stab at it or try to clarify what's there if this is unsatisfactory.  but it does at least remove a minor inaccuracy and add some explanation where there was previously none.