### PR TITLE
Componentize facet hierarchy rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ You can skip as many levels as you'd like, as long as the "leaf" values are inde
 
 **Note**: If you use Solr's built-in [PathHierarchyTokenizerFactory](http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters#solr.PathHierarchyTokenizerFactory), you can index the entire depth by supplying only the leaf nodes.  Otherwise you are expected to build the permutations yourself before loading.
 
-In your Blacklight controller configuration (usually `CatalogController`), tell Blacklight to render the facet using the hierarchy partial.
+In your Blacklight controller configuration (usually `CatalogController`), tell Blacklight to render the facet using the hierarchy component.
 
 
 ```ruby
-config.add_facet_field 'queue_wps',   :label => 'Queue Status', :partial => 'blacklight/hierarchy/facet_hierarchy'
-config.add_facet_field 'queue_wsp',   :label => 'Queue Status', :partial => 'blacklight/hierarchy/facet_hierarchy'
-config.add_facet_field 'queue_swp',   :label => 'Queue Status', :partial => 'blacklight/hierarchy/facet_hierarchy'
-config.add_facet_field 'callnum_top', :label => 'Callnumber',   :partial => 'blacklight/hierarchy/facet_hierarchy'
-config.add_facet_field 'foo_trunk',   :label => 'Foo L1',       :partial => 'blacklight/hierarchy/facet_hierarchy'
-config.add_facet_field 'foo_branch',  :label => 'Foo L2',       :partial => 'blacklight/hierarchy/facet_hierarchy'
-config.add_facet_field 'foo_leaves',  :label => 'Foo L3',       :partial => 'blacklight/hierarchy/facet_hierarchy'
-config.add_facet_field 'tag_facet',   :label => 'Tag',          :partial => 'blacklight/hierarchy/facet_hierarchy'
+config.add_facet_field 'queue_wps',   label: 'Queue Status', component: Blacklight::Hierarchy::FacetFieldListComponent
+config.add_facet_field 'queue_wsp',   label: 'Queue Status', component: Blacklight::Hierarchy::FacetFieldListComponent
+config.add_facet_field 'queue_swp',   label: 'Queue Status', component: Blacklight::Hierarchy::FacetFieldListComponent
+config.add_facet_field 'callnum_top', label: 'Callnumber',   component: Blacklight::Hierarchy::FacetFieldListComponent
+config.add_facet_field 'foo_trunk',   label: 'Foo L1',       component: Blacklight::Hierarchy::FacetFieldListComponent
+config.add_facet_field 'foo_branch',  label: 'Foo L2',       component: Blacklight::Hierarchy::FacetFieldListComponent
+config.add_facet_field 'foo_leaves',  label: 'Foo L3',       component: Blacklight::Hierarchy::FacetFieldListComponent
+config.add_facet_field 'tag_facet',   label: 'Tag',          component: Blacklight::Hierarchy::FacetFieldListComponent
 ```
 
 Add your hierarchy-specific options to the controller configuration:

--- a/app/components/blacklight/hierarchy/facet_field_list_component.html.erb
+++ b/app/components/blacklight/hierarchy/facet_field_list_component.html.erb
@@ -1,0 +1,10 @@
+<%= render(@layout.new(facet_field: @facet_field)) do |component| %>
+  <% component.with(:label) do %>
+    <%= @facet_field.label %>
+  <% end %>
+  <% component.with(:body) do %>
+    <ul class="facet-hierarchy" role="tree">
+      <%= render_hierarchy %>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/components/blacklight/hierarchy/facet_field_list_component.rb
+++ b/app/components/blacklight/hierarchy/facet_field_list_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Hierarchy
+    class FacetFieldListComponent < Blacklight::FacetFieldListComponent
+      def render_hierarchy
+        helpers.render_hierarchy(@facet_field.facet_field)
+      end
+    end
+  end
+end

--- a/app/views/blacklight/hierarchy/_facet_hierarchy.html.erb
+++ b/app/views/blacklight/hierarchy/_facet_hierarchy.html.erb
@@ -1,3 +1,7 @@
+<% Deprecation.warn(self, "Calling the blacklight/hierarchy/facet_hierarchy partial is " \
+  "deprecated and will be removed in blacklight-hierarchy 5.0. Replace the facet config for '#{facet_field.key}':\n\n\t" \
+  ":partial => 'blacklight/hierarchy/facet_hierarchy'\n\nwith:\n\n\t" \
+  ":component => Blacklight::Hierarchy::FacetFieldListComponent\n\n") %>
 <ul class="facet-hierarchy" role="tree">
   <%= render_hierarchy(facet_field) %>
 </ul>

--- a/blacklight-hierarchy.gemspec
+++ b/blacklight-hierarchy.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  # Most likely available for even earlier versions of Blacklight, but this is what I validated
-  s.add_dependency 'blacklight', '> 6.20', '< 8.0'
+  # A version of blacklight with view_component is required
+  s.add_dependency 'blacklight', '~> 7.9'
   s.add_dependency 'rails', '>= 5.1', '< 7'
   s.add_dependency 'jquery-rails'
 

--- a/spec/features/basic_spec.rb
+++ b/spec/features/basic_spec.rb
@@ -99,9 +99,8 @@ describe 'config_1' do
     before do
       CatalogController.blacklight_config = Blacklight::Configuration.new
       CatalogController.configure_blacklight do |config|
-        #   config.add_facet_field 'rotate_tag_facet', :label => 'Tag',     :partial => 'blacklight/hierarchy/facet_hierarchy'
-        config.add_facet_field 'tag_facet',    label: 'Tag',         partial: 'blacklight/hierarchy/facet_hierarchy'
-        config.add_facet_field 'my_top_facet', label: 'Slash Delim', partial: 'blacklight/hierarchy/facet_hierarchy'
+        config.add_facet_field 'tag_facet',    label: 'Tag',         component: Blacklight::Hierarchy::FacetFieldListComponent
+        config.add_facet_field 'my_top_facet', label: 'Slash Delim', component: Blacklight::Hierarchy::FacetFieldListComponent
         config.facet_display = {
           hierarchy: {
             #       'rotate' => [['tag'  ], ':'], # this would work if config.add_facet_field was called rotate_tag_facet, instead of tag_facet, I think.
@@ -119,8 +118,8 @@ describe 'config_2' do
     before do
       CatalogController.blacklight_config = Blacklight::Configuration.new
       CatalogController.configure_blacklight do |config|
-        config.add_facet_field 'tag_facet',    label: 'Tag',         partial: 'blacklight/hierarchy/facet_hierarchy'
-        config.add_facet_field 'my_top_facet', label: 'Slash Delim', partial: 'blacklight/hierarchy/facet_hierarchy'
+        config.add_facet_field 'tag_facet',    label: 'Tag',         component: Blacklight::Hierarchy::FacetFieldListComponent
+        config.add_facet_field 'my_top_facet', label: 'Slash Delim', component: Blacklight::Hierarchy::FacetFieldListComponent
         config.facet_display = {
           hierarchy: {
             'tag'    => [['facet']], # rely on default delim


### PR DESCRIPTION
This allows blacklight-hierarchy to be used with the new component rendering, thus avoiding deprecation errors.