### PR TITLE
Make jquery a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ en:
       toggle_aria_label: Toggle call number section
 ```
 
+### Javascript
+
+The javascript in this project requires jquery, but it's up to you to provide it in a way that best works for your project.  You may consider the jquery-rails gem or if you use webpacker, you could use the jquery npm package.
+
 ## Caveats
 
 This code was ripped out of another project, and is still quite immature as a standalone project. Every effort has been made to make it as plug-and-play as possible, but it may stomp on Blacklight in unintended ways (e.g., ways that made sense in context of its former host app, but which aren't compatible with generic Blacklight). Proceed with caution, and report issues.

--- a/blacklight-hierarchy.gemspec
+++ b/blacklight-hierarchy.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   # Most likely available for even earlier versions of Blacklight, but this is what I validated
   s.add_dependency 'blacklight', '> 6.20', '< 8.0'
   s.add_dependency 'rails', '>= 5.1', '< 7'
-  s.add_dependency 'jquery-rails'
 
   s.add_development_dependency 'rsolr'
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
That is, it's up to the user to provide it. This means webpacker users don't get the jquery-rails gem, which they don't need.