### PR TITLE
Align the remove link with Blacklight 7

### DIFF
--- a/app/components/blacklight/hierarchy/selected_qfacet_value_component.html.erb
+++ b/app/components/blacklight/hierarchy/selected_qfacet_value_component.html.erb
@@ -1,4 +1,5 @@
 <span class="selected"><%= render Blacklight::Hierarchy::QfacetValueComponent.new(field_name: field_name, item: item, suppress_link: true) %></span>
-<%= link_to remove_href, class: 'remove' do %>
-  <span class="glyphicon glyphicon-remove"></span><span class="sr-only">[remove]</span>
+<%= link_to(remove_href, class: 'btn btn-outline-secondary remove') do %>
+  <span class="remove-icon" aria-hidden="true">✖</span>
+  <span class="sr-only"><%= t('blacklight.search.facets.selected.remove') %></span>
 <% end %>


### PR DESCRIPTION
Blacklight 7 does not use glyphicons, so the existing remove link does not render. This aligns with what is rendered by: https://github.com/projectblacklight/blacklight/blob/c310fc8cb07635cac8e2474b1afa9fafdb6c89de/app/components/blacklight/facet_item_component.rb#L88-L91