### PR TITLE
Test on Ruby 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6, 2.7]
+        ruby: [2.7, 3.0]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.5, 2.6]
+        ruby: [2.7, 2.6]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
Also drops 2.5 since it is EOL: https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-5-9-released/