### PR TITLE
Remove unnecessary classes

### DIFF
--- a/app/components/blacklight/hierarchy/selected_qfacet_value_component.html.erb
+++ b/app/components/blacklight/hierarchy/selected_qfacet_value_component.html.erb
@@ -1,5 +1,5 @@
 <span class="selected"><%= render Blacklight::Hierarchy::QfacetValueComponent.new(field_name: field_name, item: item, suppress_link: true) %></span>
-<%= link_to(remove_href, class: 'btn btn-outline-secondary remove') do %>
+<%= link_to(remove_href, class: 'remove') do %>
   <span class="remove-icon" aria-hidden="true">✖</span>
   <span class="sr-only"><%= t('blacklight.search.facets.selected.remove') %></span>
 <% end %>


### PR DESCRIPTION
to align with the facet remove button in blacklight: https://github.com/projectblacklight/blacklight/blob/c310fc8cb07635cac8e2474b1afa9fafdb6c89de/app/components/blacklight/facet_item_component.rb#L89

This was mistakenly added in #48