### PR TITLE
Add an optional stimulus controller

### DIFF
--- a/app/assets/javascripts/blacklight/hierarchy/blacklight_hierarchy_controller.js
+++ b/app/assets/javascripts/blacklight/hierarchy/blacklight_hierarchy_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from 'stimulus'
+
+export default class extends Controller {
+  static targets = [ "list" ]
+  connect() {
+    this.element.classList.add("twiddle")
+  }
+
+  toggle() {
+    this.element.classList.toggle("twiddle-open")
+  }
+}

--- a/lib/generators/blacklight_hierarchy/templates/blacklight_hierarchy.js
+++ b/lib/generators/blacklight_hierarchy/templates/blacklight_hierarchy.js
@@ -1,1 +1,9 @@
 //= require blacklight/hierarchy/hierarchy
+
+// If you use Stimulus in your application you can remove the line above and require
+// blacklight_hierarchy_controller instead:
+//
+// import BlacklightHierarchyController from 'blacklight-hierarchy/app/assets/javascripts/blacklight/hierarchy/blacklight_hierarchy_controller'
+// import { Application } from 'stimulus'
+// const application = Application.start()
+// application.register("b-h-collapsible", BlacklightHierarchyController)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacklight-hierarchy",
-  "version": "4.1.0",
+  "version": "5.1.0-alpha1",
   "description": "[![Build Status](https://github.com/sul-dlss/blacklight-hierarchy/workflows/CI/badge.svg)](https://github.com/sul-dlss/blacklight-hierarchy/actions?query=branch%3Amain)",
   "main": "app/assets/javascripts/blacklight/hierarchy/hierarchy.js",
   "files": [


### PR DESCRIPTION
This is helpful in our application where the facet is lazily loaded.  The exising javascript only binds the actions at page load, but our elements, being lazily loaded are not yet on the page.  Stimulus binds actions on any page mutation.