### PR TITLE
Set the data target correctly

### DIFF
--- a/app/components/blacklight/hierarchy/facet_field_component.html.erb
+++ b/app/components/blacklight/hierarchy/facet_field_component.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 
   <% unless subset.empty? %>
-    <ul id="<%= ul_id %>" data-b-h-collapsible-target="list" role=\"group\">
+    <ul id="<%= ul_id %>" class="collapse" data-b-h-collapsible-target="list" role=\"group\">
     <% subset.keys.sort.each do |subkey| %>
       <%= render self.class.new(field_name: field_name, tree: subset[subkey], key: subkey) %>
     <% end %>

--- a/app/helpers/blacklight/hierarchy_helper.rb
+++ b/app/helpers/blacklight/hierarchy_helper.rb
@@ -17,7 +17,7 @@ module Blacklight::HierarchyHelper
                data: {
                  action: 'click->b-h-collapsible#toggle',
                  toggle: 'collapse',
-                 target: controls
+                 target: "##{controls}"
                },
                class: 'toggle-handle') do
       tag.span(Blacklight::Hierarchy::Engine.config.closed_icon, :'aria-hidden' => 'true', class: 'closed') +


### PR DESCRIPTION
with a preceding octothorp. Otherwise the Bootstrap collapse function can't find the target.

This also adds the required `collapse` class, so the list is collapsed by default.