### PR TITLE
Remove unnecessary manifest link

### DIFF
--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -21,8 +21,4 @@ class TestAppGenerator < Rails::Generators::Base
   def create_images_directory
     run 'mkdir app/assets/images'
   end
-
-  def add_js_reference
-    inject_into_file 'app/assets/config/manifest.js', "\n//= link application.js", after: '//= link_directory ../stylesheets .css'
-  end
 end


### PR DESCRIPTION
This causes the following error
```
     Failure/Error:
       raise DoubleLinkError.new(
         parent_filename: parent_asset.filename,
         last_filename:   last_filename,
         logical_path:    asset.logical_path,
         filename:        asset.filename
       )

     ActionView::Template::Error:
       Multiple files with the same output path cannot be linked ("application.js")
       In "/Users/jcoyne85/workspace/sul-dlss/blacklight-hierarchy/.internal_test_app/app/assets/config/manifest.js" these files were linked:
         - /Users/jcoyne85/workspace/sul-dlss/blacklight-hierarchy/.internal_test_app/app/assets/javascripts/application.js
         - /Users/jcoyne85/workspace/sul-dlss/blacklight-hierarchy/.internal_test_app/app/javascript/application.js
```