### PR TITLE
Improve markup and styles; add support for configurable sort and Face…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,26 @@ In the above configuration, 'queue_status_facet' is the full Solr field name, an
 
 The `[nil]` value is present in support of rotatable facet hierarchies, a totally undocumented feature.
 
+You may optionally configure a custom facet item presenter, e.g.:
+
+```ruby
+config.facet_display = {
+  :hierarchy => {
+    'location_hierarchy' => [['f'], ':', MyApp::CustomFacetItemPresenter] # values are arrays: 1st element is array, 2nd is delimiter string, 3rd is a presenter
+  }
+}
+```
+
 Facet fields should be added for each permutation of hierarchy key and term values, joined by **_**.  Or, the output of:
 
 ```ruby
 config.facet_display[:hierarchy].each{ |k,v| puts "#{k}_#{v}" }
+```
+### Sorting
+Sorting for a hierarchical facet item list is configured just like a non-hierarchical Blacklight facet. By default, the list sorts by count. To specify alphabetical sorting, use `sort: 'alpha'` in `config.add_facet_field`, e.g.:
+
+```ruby
+config.add_facet_field 'tag_facet', sort: 'alpha', label: 'Tag', component: Blacklight::Hierarchy::FacetFieldListComponent
 ```
 
 ### Changing the icons

--- a/app/assets/stylesheets/blacklight/hierarchy/hierarchy.scss
+++ b/app/assets/stylesheets/blacklight/hierarchy/hierarchy.scss
@@ -8,30 +8,40 @@ $text-muted: #777 !default;
 .facet-hierarchy {
   list-style-type: none;
   padding-left: 0;
+  flex: 1 1 100%;
+  width: 100%;
 
   ul {
-    border-bottom: 0;
     list-style-type: none;
-    padding-bottom: 0;
-    padding-left: 1.3em;
+    padding-left: 0.75rem;
+    flex: 1 1 100%;
+    width: 100%;
   }
 
-  .facet_select {
-    display: inline-block;
-    margin-bottom: 6px;
-    max-width: calc(100% - 5em);
+  .facet-label {
+    flex: 1;
+  }
+
+  .facet-select {
+    flex: 1;
+    word-break: break-word;
   }
 
   .facet-count {
     float: right;
+    flex: 0 0 auto;
+    padding-left: 0.5rem;
   }
 
   .toggle-handle {
     border: 0;
     margin: 0;
-    min-width: 1em;
+    width: 1.5rem;
+    height: 1.5rem;
     padding: 0;
     vertical-align: top;
+    display: flex;
+    align-items: flex-start;
 
     .closed,
     .opened {
@@ -46,9 +56,9 @@ $text-muted: #777 !default;
   .twiddle>.toggle-handle .toggle-icon {
     background-position: center;
     background-repeat: no-repeat;
-    margin-top: 3px;
-    min-height: 20px;
-    min-width: 20px;
+    margin-top: 0.25rem;
+    min-height: 1.1rem;
+    min-width: 1.1rem;
   }
 
   .twiddle>.toggle-handle .closed {
@@ -69,12 +79,14 @@ $text-muted: #777 !default;
     display: inline-block;
   }
 
-  .h-leaf {
-    padding-left: 1.3em;
+  .h-node, .h-leaf {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 3px 0;
   }
 
-  .h-node {
-    cursor: pointer;
+  .h-leaf {
+    padding-left: 1.5rem;
   }
 
   .remove {

--- a/app/components/blacklight/hierarchy/facet_field_component.html.erb
+++ b/app/components/blacklight/hierarchy/facet_field_component.html.erb
@@ -11,7 +11,7 @@
 
   <% unless subset.empty? %>
     <ul id="<%= ul_id %>" class="collapse" data-b-h-collapsible-target="list" role="group">
-    <% subset.keys.sort.each do |subkey| %>
+    <% subset.keys.each do |subkey| %>
       <%= render self.class.new(field_name: field_name, tree: subset[subkey], key: subkey) %>
     <% end %>
     </ul>

--- a/app/components/blacklight/hierarchy/facet_field_list_component.html.erb
+++ b/app/components/blacklight/hierarchy/facet_field_list_component.html.erb
@@ -4,7 +4,7 @@
   <% end %>
   <% component.with_body do %>
     <ul class="facet-hierarchy" role="tree">
-      <% tree.keys.sort.collect do |key| %>
+      <% tree.keys.collect do |key| %>
         <%= render Blacklight::Hierarchy::FacetFieldComponent.new(field_name: @facet_field.facet_field.field, tree: tree[key], key: key) %>
       <% end %>
     </ul>

--- a/app/components/blacklight/hierarchy/facet_field_list_component.rb
+++ b/app/components/blacklight/hierarchy/facet_field_list_component.rb
@@ -3,7 +3,7 @@
 module Blacklight
   module Hierarchy
     class FacetFieldListComponent < Blacklight::FacetFieldListComponent
-      DELIMETER = '_'
+      DELIMITER = '_'
 
       # @param [Blacklight::Configuration::FacetField] as defined in controller with config.add_facet_field (and with :partial => 'blacklight/hierarchy/facet_hierarchy')
       # @return [String] html for the facet tree
@@ -42,7 +42,7 @@ module Blacklight
       #  might contain values like ['LB', 'LB/2395', 'LB/2395/.C65', 'LB/2395/.C65/1991'].
       # note: the suffixes (e.g. 'ssim' for 'exploded_tag' in the above example) can't have underscores, otherwise things break.
       def prefix
-        @prefix ||= field_name.gsub("#{DELIMETER}#{field_name.split(/#{DELIMETER}/).last}", '')
+        @prefix ||= field_name.gsub("#{DELIMITER}#{field_name.split(/#{DELIMITER}/).last}", '')
       end
 
       delegate :blacklight_config, to: :helpers

--- a/app/components/blacklight/hierarchy/qfacet_value_component.html.erb
+++ b/app/components/blacklight/hierarchy/qfacet_value_component.html.erb
@@ -1,1 +1,4 @@
-<%= link_to_unless suppress_link, item.value, path_for_facet, id: id, class: 'facet_select' %> <%= render_facet_count %>
+<span class="facet-label">
+  <%= link_to label_value, path_for_facet, id: id, class: 'facet-select', rel: 'nofollow' %>
+</span>
+<%= render_facet_count %>

--- a/app/components/blacklight/hierarchy/qfacet_value_component.rb
+++ b/app/components/blacklight/hierarchy/qfacet_value_component.rb
@@ -12,14 +12,34 @@ module Blacklight
 
       attr_reader :field_name, :item, :id, :suppress_link
 
+      def label_value
+        return item.value if facet_item_presenter_class == Blacklight::FacetItemPresenter
+        facet_item_presenter_class.new(item.qvalue, facet_config, helpers, field_name).label
+      end
+
       def path_for_facet
-        facet_config = helpers.facet_configuration_for_field(field_name)
-        Blacklight::FacetItemPresenter.new(item.qvalue, facet_config, helpers, field_name).href
+        facet_item_presenter_class.new(item.qvalue, facet_config, helpers, field_name).href
       end
 
       def render_facet_count
         classes = "facet-count"
         content_tag("span", t('blacklight.search.facets.count', number: number_with_delimiter(item.hits)), class: classes)
+      end
+
+      def facet_config
+        helpers.facet_configuration_for_field(field_name)
+      end
+
+      def hierarchy_config
+        helpers.blacklight_config.facet_display[:hierarchy]
+      end
+
+      def field_name_prefix
+        @field_name_prefix ||= field_name.gsub("_#{field_name.split(/_/).last}", '')
+      end
+
+      def facet_item_presenter_class
+        hierarchy_config.dig(field_name_prefix)[2] || Blacklight::FacetItemPresenter
       end
     end
   end

--- a/app/components/blacklight/hierarchy/selected_qfacet_value_component.html.erb
+++ b/app/components/blacklight/hierarchy/selected_qfacet_value_component.html.erb
@@ -1,5 +1,8 @@
-<span class="selected"><%= render Blacklight::Hierarchy::QfacetValueComponent.new(field_name: field_name, item: item, suppress_link: true) %></span>
+<span class="facet-label">
+  <%= content_tag :span, label_value, id: id, class: 'selected' %>
+</span>
 <%= link_to(remove_href, class: 'remove') do %>
   <span class="remove-icon" aria-hidden="true">✖</span>
   <span class="sr-only"><%= t('blacklight.search.facets.selected.remove') %></span>
 <% end %>
+<%= render_facet_count %>

--- a/app/components/blacklight/hierarchy/selected_qfacet_value_component.rb
+++ b/app/components/blacklight/hierarchy/selected_qfacet_value_component.rb
@@ -3,7 +3,7 @@
 module Blacklight
   module Hierarchy
     # Standard display of a SELECTED facet value, no link, special span with class, and 'remove' button.
-    class SelectedQfacetValueComponent < ::ViewComponent::Base
+    class SelectedQfacetValueComponent < QfacetValueComponent
       def initialize(field_name:, item:)
         @field_name = field_name
         @item = item

--- a/spec/features/basic_spec.rb
+++ b/spec/features/basic_spec.rb
@@ -29,14 +29,14 @@ RSpec.describe 'Basic feature specs', type: :feature do
   end
 
   before do
-    rsolr_client = double('rsolr_client')
+    rsolr_client = instance_double(RSolr::Client)
     allow(rsolr_client).to receive(:send_and_receive).and_return solr_facet_resp
     allow(RSolr).to receive(:connect).and_return rsolr_client
   end
 
   shared_examples 'catalog' do
     context 'facet tree without repeated nodes' do
-      it 'should display the hierarchy' do
+      it 'displays the hierarchy' do
         visit '/'
         expect(page).to have_selector('li.h-node[data-controller="b-h-collapsible"]', text: 'a')
         expect(page).to have_selector('li.h-node > ul > li.h-node[data-controller="b-h-collapsible"]', text: 'b')
@@ -52,14 +52,14 @@ RSpec.describe 'Basic feature specs', type: :feature do
         expect(page).to have_selector('.facet-hierarchy > li.h-leaf', text: 'n 1')
       end
 
-      it 'should properly link the hierarchy' do
+      it 'properly links the hierarchy' do
         visit '/'
         expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['n'] }))
         expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['a:b:c'] }))
         expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['x:y'] }))
       end
 
-      it 'should work with a different value delimiter' do
+      it 'works with a different value delimiter' do
         visit '/'
         expect(page).to have_selector('li.h-node', text: 'f')
         expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'g')
@@ -86,7 +86,7 @@ RSpec.describe 'Basic feature specs', type: :feature do
             'facet_ranges' => {}
           } }
       end
-      it 'should display all child nodes when a node value is repeated at its child level' do
+      it 'displays all child nodes when a node value is repeated at its child level' do
         visit '/'
         expect(page).to have_selector('li.h-node', text: 'm')
         expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'w')
@@ -107,7 +107,6 @@ RSpec.describe 'Basic feature specs', type: :feature do
           config.add_facet_field 'my_top_facet', label: 'Slash Delim', component: Blacklight::Hierarchy::FacetFieldListComponent
           config.facet_display = {
             hierarchy: {
-              #       'rotate' => [['tag'  ], ':'], # this would work if config.add_facet_field was called rotate_tag_facet, instead of tag_facet, I think.
               'tag' => [['facet'], ':'], # stupidly, the facet field is expected to have an underscore followed by SOMETHING;  in this case it is "facet"
               'my_top' => [['facet'], '/']
             }

--- a/spec/features/basic_spec.rb
+++ b/spec/features/basic_spec.rb
@@ -1,131 +1,256 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-shared_examples 'catalog' do
-  context 'facet tree without repeated nodes' do
-    before do
-      solr_facet_resp = { 'responseHeader' => { 'status' => 0, 'QTime' => 4, 'params' => { 'wt' => 'ruby', 'rows' => '0' } },
-                          'response' => { 'numFound' => 30, 'start' => 0, 'maxScore' => 1.0, 'docs' => [] },
-                          'facet_counts' => {
-                            'facet_queries' => {},
-                            'facet_fields' => {
-                              'tag_facet' => [
-                                'a:b:c', 30,
-                                'a:b:d', 25,
-                                'a:c:d', 5,
-                                'p:r:q', 25,
-                                'x:y', 5,
-                                'n', 1],
-                              'my_top_facet' => [
-                                'f/g/h', 30,
-                                'j/k', 5,
-                                'z', 1]
-                            },
-                            'facet_dates' => {},
-                            'facet_ranges' => {}
-                          }
-                          }
-      rsolr_client = double('rsolr_client')
-      expect(rsolr_client).to receive(:send_and_receive).and_return solr_facet_resp
-      expect(RSolr).to receive(:connect).and_return rsolr_client
+RSpec.describe 'Basic feature specs', type: :feature do
+  let(:solr_facet_resp) do
+    { 'responseHeader' => { 'status' => 0, 'QTime' => 4, 'params' => { 'wt' => 'ruby', 'rows' => '0' } },
+      'response' => { 'numFound' => 30, 'start' => 0, 'maxScore' => 1.0, 'docs' => [] },
+      'facet_counts' => {
+        'facet_queries' => {},
+        'facet_fields' => {
+          'tag_facet' => [
+            'a:b:c', 30,
+            'a:b:d', 25,
+            'a:c:d', 5,
+            'p:r:q', 25,
+            'x:y', 5,
+            'n', 1
+          ],
+          'my_top_facet' => [
+            'f/g/h', 30,
+            'j/k', 5,
+            'z', 1
+          ]
+        },
+        'facet_dates' => {},
+        'facet_ranges' => {}
+      } }
+  end
+
+  before do
+    rsolr_client = double('rsolr_client')
+    allow(rsolr_client).to receive(:send_and_receive).and_return solr_facet_resp
+    allow(RSolr).to receive(:connect).and_return rsolr_client
+  end
+
+  shared_examples 'catalog' do
+    context 'facet tree without repeated nodes' do
+      it 'should display the hierarchy' do
+        visit '/'
+        expect(page).to have_selector('li.h-node[data-controller="b-h-collapsible"]', text: 'a')
+        expect(page).to have_selector('li.h-node > ul > li.h-node[data-controller="b-h-collapsible"]', text: 'b')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'c 30')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'd 25')
+        expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'c')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'd 5')
+        expect(page).to have_selector('li.h-node', text: 'p')
+        expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'r')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'q 25')
+        expect(page).to have_selector('li.h-node', text: 'x')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'y 5')
+        expect(page).to have_selector('.facet-hierarchy > li.h-leaf', text: 'n 1')
+      end
+
+      it 'should properly link the hierarchy' do
+        visit '/'
+        expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['n'] }))
+        expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['a:b:c'] }))
+        expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['x:y'] }))
+      end
+
+      it 'should work with a different value delimiter' do
+        visit '/'
+        expect(page).to have_selector('li.h-node', text: 'f')
+        expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'g')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'h 30')
+        expect(page).to have_selector('li.h-node', text: 'j')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'k 5')
+        expect(page).to have_selector('.facet-hierarchy > li.h-leaf', text: 'z 1')
+      end
     end
 
-    it 'should display the hierarchy' do
-      visit '/'
-      expect(page).to have_selector('li.h-node[data-controller="b-h-collapsible"]', text: 'a')
-      expect(page).to have_selector('li.h-node > ul > li.h-node[data-controller="b-h-collapsible"]', text: 'b')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'c 30')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'd 25')
-      expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'c')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'd 5')
-      expect(page).to have_selector('li.h-node', text: 'p')
-      expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'r')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'q 25')
-      expect(page).to have_selector('li.h-node', text: 'x')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'y 5')
-      expect(page).to have_selector('.facet-hierarchy > li.h-leaf', text: 'n 1')
-    end
-
-    it 'should properly link the hierarchy' do
-      visit '/'
-      expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['n'] }))
-      expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['a:b:c'] }))
-      expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['x:y'] }))
-    end
-
-    it 'should work with a different value delimiter' do
-      visit '/'
-      expect(page).to have_selector('li.h-node', text: 'f')
-      expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'g')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'h 30')
-      expect(page).to have_selector('li.h-node', text: 'j')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'k 5')
-      expect(page).to have_selector('.facet-hierarchy > li.h-leaf', text: 'z 1')
-    end
-  end # facet tree without repeated nodes
-
-  context 'facet tree with repeated nodes' do
-    before do
-      facet_resp = { 'responseHeader' => { 'status' => 0, 'QTime' => 4, 'params' => { 'wt' => 'ruby', 'rows' => '0' } },
-                     'response' => { 'numFound' => 30, 'start' => 0, 'maxScore' => 1.0, 'docs' => [] },
-                     'facet_counts' => {
-                       'facet_queries' => {},
-                       'facet_fields' => {
-                         'tag_facet' => [
-                           'm:w:w:t', 15,
-                           'm:w:v:z', 10]
-                       },
-                       'facet_dates' => {},
-                       'facet_ranges' => {}
-                     }
-                    }
-      my_rsolr_client = double('rsolr_client')
-      expect(my_rsolr_client).to receive(:send_and_receive).and_return facet_resp
-      expect(RSolr).to receive(:connect).and_return my_rsolr_client
-    end
-    it 'should display all child nodes when a node value is repeated at its child level' do
-      visit '/'
-      expect(page).to have_selector('li.h-node', text: 'm')
-      expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'w')
-      expect(page).to have_selector('li.h-node > ul > li.h-node > ul > li.h-node', text: 'w')
-      expect(page).to have_selector('li.h-node > ul > li.h-node > ul > li.h-node', text: 'v')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 't 15')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'z 10')
+    context 'facet tree with repeated nodes' do
+      let(:solr_facet_resp) do
+        { 'responseHeader' => { 'status' => 0, 'QTime' => 4, 'params' => { 'wt' => 'ruby', 'rows' => '0' } },
+          'response' => { 'numFound' => 30, 'start' => 0, 'maxScore' => 1.0, 'docs' => [] },
+          'facet_counts' => {
+            'facet_queries' => {},
+            'facet_fields' => {
+              'tag_facet' => [
+                'm:w:w:t', 15,
+                'm:w:v:z', 10
+              ]
+            },
+            'facet_dates' => {},
+            'facet_ranges' => {}
+          } }
+      end
+      it 'should display all child nodes when a node value is repeated at its child level' do
+        visit '/'
+        expect(page).to have_selector('li.h-node', text: 'm')
+        expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'w')
+        expect(page).to have_selector('li.h-node > ul > li.h-node > ul > li.h-node', text: 'w')
+        expect(page).to have_selector('li.h-node > ul > li.h-node > ul > li.h-node', text: 'v')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 't 15')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'z 10')
+      end
     end
   end
-end
 
-describe 'config_1' do
-  it_behaves_like 'catalog' do
+  describe 'config_1' do
+    it_behaves_like 'catalog' do
+      before do
+        CatalogController.blacklight_config = Blacklight::Configuration.new
+        CatalogController.configure_blacklight do |config|
+          config.add_facet_field 'tag_facet',    label: 'Tag',         component: Blacklight::Hierarchy::FacetFieldListComponent
+          config.add_facet_field 'my_top_facet', label: 'Slash Delim', component: Blacklight::Hierarchy::FacetFieldListComponent
+          config.facet_display = {
+            hierarchy: {
+              #       'rotate' => [['tag'  ], ':'], # this would work if config.add_facet_field was called rotate_tag_facet, instead of tag_facet, I think.
+              'tag' => [['facet'], ':'], # stupidly, the facet field is expected to have an underscore followed by SOMETHING;  in this case it is "facet"
+              'my_top' => [['facet'], '/']
+            }
+          }
+        end
+      end
+    end
+  end
+
+  describe 'config_2' do
+    it_behaves_like 'catalog' do
+      before do
+        CatalogController.blacklight_config = Blacklight::Configuration.new
+        CatalogController.configure_blacklight do |config|
+          config.add_facet_field 'tag_facet',    label: 'Tag',         component: Blacklight::Hierarchy::FacetFieldListComponent
+          config.add_facet_field 'my_top_facet', label: 'Slash Delim', component: Blacklight::Hierarchy::FacetFieldListComponent
+          config.facet_display = {
+            hierarchy: {
+              'tag' => [['facet']], # rely on default delim
+              'my_top' => [['facet'], '/']
+            }
+          }
+        end
+      end
+    end
+  end
+
+  describe 'configure labels via a custom FacetItemPresenter' do
     before do
+      class MyCustomFacetItemPresenter < Blacklight::FacetItemPresenter
+        def label
+          # Derive a custom label from the original value
+          value.upcase
+        end
+      end
+
       CatalogController.blacklight_config = Blacklight::Configuration.new
       CatalogController.configure_blacklight do |config|
-        config.add_facet_field 'tag_facet',    label: 'Tag',         component: Blacklight::Hierarchy::FacetFieldListComponent
-        config.add_facet_field 'my_top_facet', label: 'Slash Delim', component: Blacklight::Hierarchy::FacetFieldListComponent
+        config.add_facet_field 'tag_facet', label: 'Tag', component: Blacklight::Hierarchy::FacetFieldListComponent
         config.facet_display = {
           hierarchy: {
-            #       'rotate' => [['tag'  ], ':'], # this would work if config.add_facet_field was called rotate_tag_facet, instead of tag_facet, I think.
-            'tag'    => [['facet'], ':'], # stupidly, the facet field is expected to have an underscore followed by SOMETHING;  in this case it is "facet"
-            'my_top' => [['facet'], '/']
+            'tag' => [['facet'], ':', MyCustomFacetItemPresenter] # configure a custom presenter
           }
         }
       end
     end
-  end
-end
 
-describe 'config_2' do
-  it_behaves_like 'catalog' do
-    before do
-      CatalogController.blacklight_config = Blacklight::Configuration.new
-      CatalogController.configure_blacklight do |config|
-        config.add_facet_field 'tag_facet',    label: 'Tag',         component: Blacklight::Hierarchy::FacetFieldListComponent
-        config.add_facet_field 'my_top_facet', label: 'Slash Delim', component: Blacklight::Hierarchy::FacetFieldListComponent
-        config.facet_display = {
-          hierarchy: {
-            'tag'    => [['facet']], # rely on default delim
-            'my_top' => [['facet'], '/']
+    it 'uses custom labels for the facet items' do
+      visit '/'
+      expect(page).to have_selector('li.h-node li.h-leaf', text: 'A:B:C 30')
+      expect(page).to have_selector('li.h-node li.h-leaf', text: 'A:B:D 25')
+      expect(page).to have_selector('li.h-node li.h-leaf', text: 'A:C:D 5')
+    end
+  end
+
+  describe 'Item sort determined by existing add_facet_field config' do
+    context 'with alpha sort' do
+      before do
+        CatalogController.blacklight_config = Blacklight::Configuration.new
+        CatalogController.configure_blacklight do |config|
+          config.add_facet_field 'tag_facet', sort: 'alpha', label: 'Tag', component: Blacklight::Hierarchy::FacetFieldListComponent
+          config.facet_display = {
+            hierarchy: {
+              'tag' => [['facet'], ':']
+            }
           }
-        }
+        end
+      end
+
+      # Note that sort: 'alpha' in the add_facet_field config will sort the facets in the response;
+      # This is the order in which they will render in the facet tree.
+      let(:solr_facet_resp) do
+        { 'responseHeader' => { 'status' => 0, 'QTime' => 4, 'params' => { 'wt' => 'ruby', 'rows' => '0' } },
+          'response' => { 'numFound' => 30, 'start' => 0, 'maxScore' => 1.0, 'docs' => [] },
+          'facet_counts' => {
+            'facet_queries' => {},
+            'facet_fields' => {
+              'tag_facet' => [
+                'a', 100,
+                'a:b', 80,
+                'a:b:c', 70,
+                'a:b:d', 9,
+                'a:b:e', 1,
+                'a:f', 20,
+                'g', 200,
+                'g:h', 50,
+                'g:i', 150
+              ]
+            },
+            'facet_dates' => {},
+            'facet_ranges' => {}
+          } }
+      end
+
+      it 'sorts the facet items alphabetically' do
+        visit '/'
+        facet_text = first('.facet-hierarchy').text.squish
+        expect(facet_text).to eq('a 100 b 80 c 70 d 9 e 1 f 20 g 200 h 50 i 150')
+      end
+    end
+
+    context 'with count sort' do
+      before do
+        CatalogController.blacklight_config = Blacklight::Configuration.new
+        CatalogController.configure_blacklight do |config|
+          config.add_facet_field 'tag_facet', sort: 'count', label: 'Tag', component: Blacklight::Hierarchy::FacetFieldListComponent
+          config.facet_display = {
+            hierarchy: {
+              'tag' => [['facet'], ':']
+            }
+          }
+        end
+      end
+
+      # Note that sort: 'count' in the add_facet_field config (default) will sort the facets in the response;
+      # This is the order in which they will render in the facet tree.
+      let(:solr_facet_resp) do
+        { 'responseHeader' => { 'status' => 0, 'QTime' => 4, 'params' => { 'wt' => 'ruby', 'rows' => '0' } },
+          'response' => { 'numFound' => 30, 'start' => 0, 'maxScore' => 1.0, 'docs' => [] },
+          'facet_counts' => {
+            'facet_queries' => {},
+            'facet_fields' => {
+              'tag_facet' => [
+                'g', 200,
+                'g:i', 150,
+                'g:h', 50,
+                'a', 100,
+                'a:b', 80,
+                'a:b:c', 70,
+                'a:b:d', 9,
+                'a:b:e', 1,
+                'a:f', 20
+              ]
+            },
+            'facet_dates' => {},
+            'facet_ranges' => {}
+          } }
+      end
+
+      it 'sorts the facet items by count' do
+        visit '/'
+        facet_text = first('.facet-hierarchy').text.squish
+        expect(facet_text).to eq('g 200 i 150 h 50 a 100 b 80 c 70 d 9 e 1 f 20')
       end
     end
   end

--- a/spec/features/basic_spec.rb
+++ b/spec/features/basic_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe 'Basic feature specs', type: :feature do
   end
 
   before do
-    rsolr_client = instance_double(RSolr::Client)
-    allow(rsolr_client).to receive(:send_and_receive).and_return solr_facet_resp
+    rsolr_client = instance_double(RSolr::Client, send_and_receive: solr_facet_resp)
     allow(RSolr).to receive(:connect).and_return rsolr_client
   end
 


### PR DESCRIPTION
…tItemPresenter.

- Enable facets to use configured `sort` in `config.add_facet_field`, e.g., `sort: 'count'` or `sort: 'alpha'`
- Add an optional config to use a custom `FacetItemPresenter`, e.g., for a custom lookup label
- Revise markup & styles to use flexbox for better layout and more closely resemble normal BL facets
- Add `rel="nofollow"` to hierarchical facets (like normal facets)
- Ensure `cursor:pointer` style is not applied to non-interactive elements in the facets

These changes would address issues #6 & #63 .

We made these changes in a fork of `blacklight-hierarchy` to meet requirements for the Triangle Research Libraries Network (TRLN) library catalog interfaces. You can see these changes in production (with minor CSS refinements like chevrons for expand/collapse icons) at all four of our institutions:
* https://find.library.duke.edu/
* https://catalog.lib.ncsu.edu/
* https://catalog.lib.unc.edu/
* https://catalog.nccu.edu/

### Before: Wrapping
<img width="286" alt="Screenshot 2024-06-06 at 4 24 54 PM" src="https://github.com/sul-dlss/blacklight-hierarchy/assets/3933756/908f3a46-d002-4d24-9c49-955e95756c71">

* Layout did not wrap correctly with longer text

### After: Wrapping
<img width="283" alt="Screenshot 2024-06-06 at 4 34 17 PM" src="https://github.com/sul-dlss/blacklight-hierarchy/assets/3933756/27cdae5d-03be-40b5-8de3-e86673fec0a9">

* Flexbox styles ensure any combination of short/long values and counts will wrap correctly

### Before: Deeply Nested Hierarchy
<img width="288" alt="Screenshot 2024-06-06 at 4 27 27 PM" src="https://github.com/sul-dlss/blacklight-hierarchy/assets/3933756/a4cf562a-da38-412d-844f-01c96fa2be08">

* If the hierarchy was a few nodes deep, there was almost no room for the text

### After: Deeply Nested Hierarchy
<img width="280" alt="Screenshot 2024-06-06 at 4 35 18 PM" src="https://github.com/sul-dlss/blacklight-hierarchy/assets/3933756/87bd4fa7-66c6-4708-9aee-66a24ee157ee">

* Flexbox layout provides more room for deeply nested nodes

### Before: Sorting, Labels, Alignment
<img width="279" alt="Screenshot 2024-06-06 at 4 29 50 PM" src="https://github.com/sul-dlss/blacklight-hierarchy/assets/3933756/b8420a08-b1a4-408b-aa33-b8eb5307b59e">

* Facet item list could only be sorted alphabetically; the field's Blacklight configuration was ignored
* Presented values could not be derived from the field values, e.g., a location code would only appear as a code
* Sibling facet items were not vertically aligned when some have child nodes and others do not

### After: Sorting, Labels, Alignment
<img width="287" alt="Screenshot 2024-06-06 at 4 36 26 PM" src="https://github.com/sul-dlss/blacklight-hierarchy/assets/3933756/3d2d62a6-c73d-4155-b015-c12f01e80652">

* Facet item list sorting uses built-in Blacklight `sort` config for `config.add_facet_field`
* Presented values can be derived from field values by using an optional `FacetItemPresenter`
* Sibling facet items are vertically aligned regardless of whether they have child nodes

