### PR TITLE
Update build matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,40 +9,42 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3']
-        rails_version: ['7.0.8']
-        blacklight_version: ['7.35.0']
+        ruby: ["3.1", "3.2", "3.3"]
+        rails_version: ["7.1.3.4"]
+        blacklight_version: ["7.37.0"]
         include:
-          - ruby: '2.7'
-            rails_version: '6.1.7.6'
-          - ruby: '3.2'
-            rails_version: '7.0.8'
-            name: 'Blacklight 8.1'
-            blacklight_version: '8.1.0'
+          - ruby: "3.1"
+            rails_version: "6.1.7.6"
+          - ruby: "3.2"
+            rails_version: "7.0.8.4"
+          - ruby: "3.3"
+            rails_version: "7.1.3.4"
+            name: "Blacklight 8.1"
+            blacklight_version: "8.1.0"
     env:
       BLACKLIGHT_VERSION: ${{ matrix.blacklight_version }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler: latest
-    - name: Install dependencies
-      run: bundle install
-      env:
-        RAILS_VERSION: ${{ matrix.rails_version }}
-    - name: Run tests
-      run: bundle exec rake ci
-      env:
-        RAILS_VERSION: ${{ matrix.rails_version }}
-        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler: latest
+      - name: Install dependencies
+        run: bundle install
+        env:
+          RAILS_VERSION: ${{ matrix.rails_version }}
+      - name: Run tests
+        run: bundle exec rake ci
+        env:
+          RAILS_VERSION: ${{ matrix.rails_version }}
+          ENGINE_CART_RAILS_OPTIONS: "--skip-git --skip-listen --skip-spring --skip-keeps --skip-coffee --skip-test"


### PR DESCRIPTION
Test on Rails 7.1.  Stop testing on deprecated ruby versions