### PR TITLE
Get ci green by removing Rails 6 and 7.0 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,10 +22,8 @@ jobs:
         rails_version: ["7.1.3.4", "7.2.0"]
         blacklight_version: ["7.38.0"]
         include:
-          - ruby: "3.1"
-            rails_version: "6.1.7.8"
           - ruby: "3.2"
-            rails_version: "7.0.8.4"
+            rails_version: "7.1.3.4"
           - ruby: "3.3"
             rails_version: "7.1.3.4"
             name: "Blacklight 8.3"

--- a/blacklight-hierarchy.gemspec
+++ b/blacklight-hierarchy.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'blacklight', '>= 7.18', '< 9'
-  s.add_dependency 'rails', '>= 6.1', '< 7.3'
+  s.add_dependency 'rails', '>= 7.1', '< 7.3'
   s.add_dependency 'deprecation'
 
   s.add_development_dependency 'rsolr'


### PR DESCRIPTION
- Update matrix to include only rails versions where logger is not broken (see [Blacklight issue](https://github.com/projectblacklight/blacklight/issues/3493))

Also updated gemspec to reflect what is being successfully tested in CI, I'm guessing this necessitates a major version release?