### PR TITLE
Explicitly support and test on Blacklight 9.0.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,7 +40,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: latest
       - name: Install dependencies
         run: bundle install
         env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,8 +30,8 @@ jobs:
             blacklight_version: "7.38.0"
           - ruby: "3.4"
             rails_version: "8.0.2"
-            name: "Blacklight 9 beta"
-            blacklight_version: "9.0.0.beta2"
+            name: "Blacklight 9"
+            blacklight_version: "9.0.0"
     env:
       BLACKLIGHT_VERSION: ${{ matrix.blacklight_version }}
     steps:

--- a/blacklight-hierarchy.gemspec
+++ b/blacklight-hierarchy.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'blacklight', '>= 7.18', '< 9'
+  s.add_dependency 'blacklight', '>= 7.18', '< 10'
   s.add_dependency 'rails', '>= 7.1', '< 9'
   s.add_dependency 'deprecation'
 


### PR DESCRIPTION
Previously, CI tested blacklight-hierarchy on blacklight 9.0.0.beta2, but in order to test and explicitly support blacklight 9.0.0, we need to bump the supported version in the gemspec.